### PR TITLE
fix(type): UnitMatches for latest Deno TypeScript version

### DIFF
--- a/src/types/unit-matches.ts
+++ b/src/types/unit-matches.ts
@@ -1,3 +1,5 @@
 import { DateUnit } from "./index.ts";
 
-export type UnitMatches = IterableIterator<[string, DateUnit, string]>;
+export type UnitMatches = IterableIterator<
+  [string, DateUnit, string] & RegExpExecArray
+>;


### PR DESCRIPTION
Simple type error fix for the latest deno / typescript version

```bash
deno --version
deno 1.42.1 (release, x86_64-unknown-linux-gnu)
v8 12.3.219.9
typescript 5.4.3
```